### PR TITLE
Removed "std:natives" module

### DIFF
--- a/standard/datatypes/json.bzi
+++ b/standard/datatypes/json.bzi
@@ -1,9 +1,9 @@
 require "std:language/parser"
-require "std:natives"
 require "std:datatypes/optional"
 require "std:datatypes/tuple"
 require "std:datatypes/list"
 require "std:datatypes/string"
+require "std:math"
 
 type JSON {
   Object(fields: list<(string, JSON)>),

--- a/standard/datatypes/list.bzi
+++ b/standard/datatypes/list.bzi
@@ -1,4 +1,7 @@
-require "std:natives"
+require "std:math"
+
+extern fn length<A>(xs: list<A>): int
+extern fn sliceFrom<A>(xs: list<A>, i: int): list<A>
 
 fn List::elem<A>(x: A, xs: list<A>): bool =>
   match xs {
@@ -11,6 +14,8 @@ fn List::map<A, B>(xs: list<A>, f: fn(A): B): list<B> =>
     case [] => []
     case [y .. ys] => [f(y)] + List::map(ys, f)
   }
+
+let map = List::map
 
 fn List::foldl<A, B>(f: fn(A, B): B, acc: B, xs: list<A>): B =>
   match xs {

--- a/standard/datatypes/mutable.bzi
+++ b/standard/datatypes/mutable.bzi
@@ -1,0 +1,2 @@
+extern fn mutable_value<A>(x: mutable<A>): A
+let value = mutable_value

--- a/standard/datatypes/string.bzi
+++ b/standard/datatypes/string.bzi
@@ -1,5 +1,7 @@
 require "std:datatypes/list"
-require "std:natives"
+require "std:math"
+
+extern fn toString<A>(x: A): string
 
 extern fn explode(s: string): list<char>
 

--- a/standard/datatypes/tuple.bzi
+++ b/standard/datatypes/tuple.bzi
@@ -1,6 +1,6 @@
-require "std:natives"
 require "std:datatypes/error"
 require "std:datatypes/list"
+require "std:math"
 
 type Tuple<A, B> {
   Tuple(x: A, y: B)

--- a/standard/http.bzi
+++ b/standard/http.bzi
@@ -1,7 +1,9 @@
 require "std:datatypes/error"
-require "std:natives"
 require "std:datatypes/tuple"
 require "std:datatypes/string"
+require "math"
+require "std:datatypes/mutable"
+require "std:datatypes/list"
 
 extern fn start_http_server(port: int): HTTP
 extern fn accept_request(server: HTTP): Request

--- a/standard/http/oak.bzi
+++ b/standard/http/oak.bzi
@@ -1,6 +1,7 @@
 require "std:http"
-require "std:natives"
 require "std:datatypes/tuple"
+require "std:math"
+require "std:datatypes/mutable"
 
 interface Oak {
   fn listen(handler: fn(): unit)
@@ -16,10 +17,6 @@ fn OakServer(port: int) => {
   actor < Oak {
     on listen(handler) => {
       handler()
-
-      http->listen(fn (req) => {
-        print("test")
-      })
 
       http->listen(fn (req) => {
         match Map::lookup(handlers.value, get_path(req)) {

--- a/standard/http/parallel.bzi
+++ b/standard/http/parallel.bzi
@@ -1,5 +1,7 @@
-require "std:natives"
 require "std:http"
+require "std:math"
+require "std:datatypes/list"
+require "std:datatypes/string"
 
 fn range(start: int, end: int): list<int> => {
   match start < end {

--- a/standard/http/websocket.bzi
+++ b/standard/http/websocket.bzi
@@ -1,4 +1,3 @@
-require "std:natives"
 require "std:http"
 
 extern fn toBase64(data: string): string

--- a/standard/io.bzi
+++ b/standard/io.bzi
@@ -1,0 +1,7 @@
+extern fn exit_with<A>(code: int): A
+extern fn print<A>(x: A)
+extern fn panic_<A>(msg: string): A
+extern fn wait_time(time: int)
+
+fn exit<A>(): A => exit_with(0)
+fn panic<A>(msg: string): A => panic_(msg)

--- a/standard/language/configurator.bzi
+++ b/standard/language/configurator.bzi
@@ -1,4 +1,5 @@
-require "std:natives"
+require "std:math"
+require "std:datatypes/mutable"
 
 extern fn execute_command(command: string)
 

--- a/standard/language/parser.bzi
+++ b/standard/language/parser.bzi
@@ -1,5 +1,6 @@
-require "std:natives"
 require "std:datatypes/list"
+require "std:math"
+require "std:datatypes/string"
 
 extern fn is_whitespace(c: char): bool
 extern fn is_digit(c: char): bool

--- a/standard/math.bzi
+++ b/standard/math.bzi
@@ -1,22 +1,12 @@
-extern fn print<A>(x: A)
-extern fn toString<A>(x: A): string
 extern fn mul_value<A>(x: A, y: A): A
 extern fn add_value<A>(x: A, y: A): A
 extern fn sub_value<A>(x: A, y: A): A
 extern fn div_value<A>(x: A, y: A): A
 extern fn mod_value<A>(x: A, y: A): A
-extern fn exit_with<A>(code: int): A
-extern fn mutable_value<A>(x: mutable<A>): A
-
-extern fn length<A>(xs: list<A>): int
-extern fn sliceFrom<A>(xs: list<A>, i: int): list<A>
 
 extern fn and_value(x: bool, y: bool): bool
 extern fn or_value(x: bool, y: bool): bool
 extern fn not_value(x: bool): bool
-
-extern fn panic_<A>(msg: string): A
-extern fn wait_time(time: int)
 
 extern fn eq_value<A>(x: A, y: A): bool
 extern fn neq_value<A>(x: A, y: A): bool
@@ -24,16 +14,6 @@ extern fn lt_value<A>(x: A, y: A): bool
 extern fn gt_value<A>(x: A, y: A): bool
 extern fn lte_value<A>(x: A, y: A): bool
 extern fn gte_value<A>(x: A, y: A): bool
-
-extern fn randomValue(): int
-extern fn itof(i: int): float
-extern fn ftoi(f: float): int
-
-// Defining basic functions
-
-let value = mutable_value
-fn exit<A>(): A => exit_with(0)
-fn panic<A>(msg: string): A => panic_(msg)
 
 let (==) = eq_value
 let (!=) = neq_value
@@ -52,10 +32,8 @@ fn (&&) (x: bool, y: bool): bool => if x then y else false
 fn (||) (x: bool, y: bool): bool => if x then true else y
 fn (!) (x: bool): bool => if x then false else true
 
-let random = randomValue
+extern fn randomValue(): int
+extern fn itof(i: int): float
+extern fn ftoi(f: float): int
 
-fn map<A, B>(xs: list<A>, f: fn(A): B): list<B> =>
-  match xs {
-    case [] => []
-    case [y .. ys] => [f(y)] + map(ys, f)
-  }
+let random = randomValue

--- a/standard/web/ui.bzi
+++ b/standard/web/ui.bzi
@@ -1,8 +1,8 @@
 require "std:language/parser"
-require "std:natives"
 require "std:datatypes/tuple"
 require "std:datatypes/error"
 require "std:datatypes/list"
+require "std:math"
 
 type HTML {
   Tag(tag: string, attributes: Map<string>, children: list<HTML>),


### PR DESCRIPTION
This PR aims at removing the natives modules from the whole standard library, and then to improve again code organization and code splitting.