### PR TITLE
Fixes about VM and new command

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -39,8 +39,6 @@ buildProgram fp = do
     void $ ppError $ "File " <> fp <> " does not exist"
     exitFailure
 
-  void . ppBuild $ "Parsing " <> fp
-
   let folder = takeDirectory fp
       fileNameWithoutDir = dropExtension $ takeFileName fp
 
@@ -55,12 +53,9 @@ buildProgram fp = do
 
   handle moduleResult . const $ do
     preHLIR <- removeRequires <$> readIORef resultState
-
-    void . ppBuild $ ("Typechecking the program" :: String)
     typedAST <- runTypechecking preHLIR
 
     handle typedAST $ \tlir -> do
-      ppBuild ("Compiling the program" :: String)
       let mlir = eraseTypes tlir
 
       closureConverted <- runClosureConversion mlir
@@ -77,12 +72,8 @@ buildProgram fp = do
 
       writeFileLBS outputFile serialized
 
-      void . ppSuccess $ "Compiled successfully to " <> outputFile
-
 buildProgramFromContent :: String -> IO ()
 buildProgramFromContent content = do
-  void . ppBuild $ ("Parsing content" :: String)
-
   let folder = "."
       fileNameWithoutDir = "main"
 
@@ -97,12 +88,7 @@ buildProgramFromContent content = do
 
   handle moduleResult . const $ do
     preHLIR <- removeRequires <$> readIORef resultState
-
-    void . ppBuild $ ("Typechecking the program" :: String)
-    typedAST <- runTypechecking preHLIR
-
-    handle typedAST $ \_ -> do
-      ppSuccess ("Typechecked successfully" :: String)
+    void $ runTypechecking preHLIR
 
 
 main :: IO ()

--- a/example/basics/factorial.bzi
+++ b/example/basics/factorial.bzi
@@ -1,5 +1,6 @@
 interface Factorial {
   fn factorial(self: actor Factorial, n: int)
+  fn finish()
 }
 
 require "std:io"
@@ -12,12 +13,19 @@ fn Factorial() => {
   actor < Factorial {
     on factorial(self, n) => {
       match n {
-        case 0 => print(acc.value)
+        case 0 => {
+          print(acc.value)
+          self->finish()
+        }
         case _ => {
           acc = acc.value * n
           self->factorial(self, n - 1)
         }
       }
+    }
+
+    on finish() => {
+      exit()
     }
   }
 }

--- a/packages/bpm/main.bzi
+++ b/packages/bpm/main.bzi
@@ -1,4 +1,4 @@
-require "std:natives"
+require "std:foundation"
 
 extern fn get_args(): list<string>
 extern fn slice<A>(xs: list<A>, start: int, end: int): list<A>
@@ -18,15 +18,15 @@ if file_exists(build_file) then {
   let bonzai_path = get_env("BONZAI_PATH")
 
   execute_command_silent("bonzaic $build_file")
-  execute_command("bonzai $build_file.bin -l \$BONZAI_PATH/bindings/bin/bindings.dylib")
+  execute_command("bonzai $build_file.bin -l $$BONZAI_PATH/bindings/bin/bindings.dylib")
 } else if length(args) == 5 then {
   let bonzai_path = get_env("BONZAI_PATH")
   let build_file = cwd + "/" + args[4]
 
   if file_exists(build_file) then {
     execute_command_silent("bonzaic $build_file")
-    print("bonzai $build_file.bin -l \$BONZAI_PATH/bindings/bin/bindings.dylib")
-    execute_command("bonzai $build_file.bin -l \$BONZAI_PATH/bindings/bin/bindings.dylib")
+    print("bonzai $build_file.bin -l $$BONZAI_PATH/bindings/bin/bindings.dylib")
+    execute_command("bonzai $build_file.bin -l $$BONZAI_PATH/bindings/bin/bindings.dylib")
   } else {
     panic("No build file found in $build_file")
   }

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -15,7 +15,7 @@
 		"postinstall": "cd client && npm install && cd ../server && npm install && cd ..",
 		"test": "sh ./scripts/e2e.sh"
 	},
-  "version": "0.0.8",
+  "version": "0.0.9",
   "engines": {
     "vscode": "^1.89.0"
   },

--- a/packages/vscode/syntaxes/bonzai.tmLanguage.json
+++ b/packages/vscode/syntaxes/bonzai.tmLanguage.json
@@ -176,7 +176,11 @@
         {
           "name": "variable.other.readwrite.bonzai",
           "match": "\\$[a-zA-Z_][a-zA-Z0-9_]*"
-        }
+        },
+				{
+					"name": "string.quoted.double.bonzai",
+					"match": "\\$\\$[a-zA-Z_][a-zA-Z0-9_]*"
+				}
       ]
     },
 

--- a/runtime/src/call.c
+++ b/runtime/src/call.c
@@ -15,6 +15,7 @@ void op_call(Module *module, Value callee, int32_t argc) {
   int32_t old_sp = module->stack->stack_pointer - argc;
 
   module->stack->stack_pointer += local_space - argc;
+  int32_t sp_before = module->stack->stack_pointer;
 
   int32_t new_pc = module->pc + 5;
 
@@ -22,7 +23,7 @@ void op_call(Module *module, Value callee, int32_t argc) {
   stack_push(module, MAKE_INTEGER(old_sp));
   stack_push(module, MAKE_INTEGER(module->base_pointer));
 
-  module->base_pointer = module->stack->stack_pointer - 3;
+  module->base_pointer = sp_before;
   module->callstack++;
 
   module->pc = ipc;

--- a/runtime/src/interpreter.c
+++ b/runtime/src/interpreter.c
@@ -213,12 +213,14 @@ Value run_interpreter(Module *module, int32_t ipc, bool does_return, int callsta
 
     HeapValue* ev = GET_PTR(event);
 
+    int old_sp = module->stack->stack_pointer;
+
     stack_push(module, event);
     stack_push(module, MAKE_INTEGER(module->pc + 5));
-    stack_push(module, MAKE_INTEGER(module->stack->stack_pointer));
+    stack_push(module, MAKE_INTEGER(old_sp));
     stack_push(module, MAKE_INTEGER(module->base_pointer));
 
-    module->base_pointer = module->stack->stack_pointer - 4;
+    module->base_pointer = old_sp;
     module->callstack++;
     module->pc = ev->as_event.ipc + 5;
     

--- a/runtime/src/module.c
+++ b/runtime/src/module.c
@@ -28,10 +28,10 @@ Frame pop_event_frame(Module* mod) {
   Value sp = mod->stack->values[mod->base_pointer + 2];
   Value bp = mod->stack->values[mod->base_pointer + 3];
 
-  ASSERT_TYPE(mod, "pop_frame", ev, TYPE_EVENT);
-  ASSERT_TYPE(mod, "pop_frame", pc, TYPE_INTEGER);
-  ASSERT_TYPE(mod, "pop_frame", sp, TYPE_INTEGER);
-  ASSERT_TYPE(mod, "pop_frame", bp, TYPE_INTEGER);
+  ASSERT_TYPE(mod, "pop_event_frame", ev, TYPE_EVENT);
+  ASSERT_TYPE(mod, "pop_event_frame", pc, TYPE_INTEGER);
+  ASSERT_TYPE(mod, "pop_event_frame", sp, TYPE_INTEGER);
+  ASSERT_TYPE(mod, "pop_event_frame", bp, TYPE_INTEGER);
 
   Frame frame = {
     .instruction_pointer = GET_INT(pc),

--- a/runtime/src/threading.c
+++ b/runtime/src/threading.c
@@ -26,11 +26,12 @@ Value call_threaded(Module *new_module, Value callee, int32_t argc, Value *argv)
   int32_t new_pc = new_module->pc + 5;
 
   new_module->gc_enabled = false;
-  Value frame = MAKE_FRAME(new_module, new_pc, old_sp, new_module->base_pointer);
-  stack_push(new_module, frame);
+  stack_push(new_module, MAKE_INTEGER(new_pc));
+  stack_push(new_module, MAKE_INTEGER(old_sp));
+  stack_push(new_module, MAKE_INTEGER(new_module->base_pointer));
   new_module->gc_enabled = true;
 
-  new_module->base_pointer = new_module->stack->stack_pointer - 1;
+  new_module->base_pointer = new_module->stack->stack_pointer - 3;
   new_module->stack->stack_pointer++;
 
   Value ret = run_interpreter(new_module, ipc, true, new_module->callstack - 1);

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -36,7 +36,7 @@ system(f"cp {executable} bin/{executable_out}")
 # Build the runtime project
 
 runtime_executable = f"bonzai-runtime{ext}"
-runtime_executable_out = f"bonzai{ext}"
+runtime_executable_out = f"bonzai-runtime{ext}"
 
 xmake_root = '--root' if is_root else ''
 system(f'xmake b {xmake_root} -P runtime bonzai-runtime')
@@ -50,9 +50,17 @@ shell_script = f"""#!/bin/sh
 bonzai $BONZAI_PATH/packages/bpm/main.bzi.bin -l $BONZAI_PATH/bindings/bin/bindings.dylib "$@"
 """
 
+bonzai_script = f"""#!/bin/sh
+{executable_out} build "$@" && {runtime_executable_out} "$@".bin -l $BONZAI_PATH/bindings/bin/bindings.dylib
+"""
+
 with open('bin/bpm', 'w') as f:
   f.write(shell_script)
 
+with open('bin/bonzai', 'w') as f:
+  f.write(bonzai_script)
+
 system('chmod +x bin/bpm')
+system('chmod +x bin/bonzai')
 
 print('Build ran successfully')

--- a/src/Language/Bonzai/Frontend/Parser/Expression.hs
+++ b/src/Language/Bonzai/Frontend/Parser/Expression.hs
@@ -47,7 +47,7 @@ parseInterpolatedString = do
 
     buildString :: [Char] -> HLIR.HLIR "expression"
     buildString [] = HLIR.MkExprLiteral (HLIR.MkLitString "")
-    buildString ('\\':'$':xs) = HLIR.MkExprBinary "+" (HLIR.MkExprString "$") (buildString xs)
+    buildString ('$':'$':xs) = HLIR.MkExprBinary "+" (HLIR.MkExprString "$") (buildString xs)
     buildString ('$':x:xs) | Lex.isIdentCharStart (Text.singleton x) = do
       -- span the variable name
       let (var, rest) = span Lex.isIdentChar xs


### PR DESCRIPTION
This PR brings some fixes to make the VM even safer. For instance, it has fixed calling conventions within threaded calls by moving from a frame to a list of frame variables (like in a real CPU).

It also brings a new command `bonzai`, which combines both `bonzaic` and `bonzai`, to allow building and directly running programs through one command.